### PR TITLE
Fix error

### DIFF
--- a/provider/main.tf
+++ b/provider/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    vcd = {
+      source = "vmware/vcd"
+      version = "3.4.0"
+    }
+  }
+}
+
 variable "vcd_user" {
     description = "vCloud user"
 }


### PR DESCRIPTION
Initializing the backend...

Initializing provider plugins...
- Finding latest version of hashicorp/vcd...
╷
│ Error: Failed to query available provider packages
│
│ Could not retrieve the list of available versions for provider hashicorp/vcd: provider registry registry.terraform.io does not have a provider named
│ registry.terraform.io/hashicorp/vcd
│
│ Did you intend to use vmware/vcd? If so, you must specify that source address in each module which requires that provider. To see which modules are currently depending
│ on hashicorp/vcd, run the following command:
│     terraform providers